### PR TITLE
Priority queue fix

### DIFF
--- a/src/AI/Util/Queue.hs
+++ b/src/AI/Util/Queue.hs
@@ -71,11 +71,18 @@ data FifoQueue a = FifoQueue [a] [a]
 instance Ord k => Queue (PriorityQueue k) where
     newQueue = undefined
     empty  (PQueue q _) = M.null q
-    pop    (PQueue q f) = (snd minAssoc,PQueue rest f)
-        where (minAssoc,rest) = M.deleteFindMin q
-    push x (PQueue q f) = PQueue (M.insert (f x) x q) f
+    pop    (PQueue q f) = (item, PQueue newPQ f)
+        where ((key, (item:items)), q') = M.deleteFindMin q
+              newPQ = if null items
+                      then q'
+                      else M.insert key items q'
+    push x (PQueue q f) = PQueue newPQ f
+        where key = (f x)
+              newPQ = case M.lookup key q of
+                      Nothing -> M.insert key [x] q
+                      Just vals -> M.insert key (x:vals) q
 
-data PriorityQueue k a = PQueue { pqueue :: M.Map k a, keyfun :: a -> k }
+data PriorityQueue k a = PQueue { pqueue :: M.Map k [a], keyfun :: a -> k }
 
 newPriorityQueue :: (a -> k) -> PriorityQueue k a
 newPriorityQueue f = PQueue M.empty f


### PR DESCRIPTION
Hi Chris.
I used your implementation of priority queue in my implementation of A*, but it didn't work well, so after fruitless debugging of my code I've found a bug in yours :) 

The problem with current implementations is that it can't store multiply values with same priority, since Data.Map keeps only one-to-one relationships and new values frequently overwrites old ones. 

For example, for 

``` haskell
take 2 $ unfoldr (Just . pop)
    $ foldr push (newPriorityQueue length) [[1, 2], [3], [4]]
```

result is [[3],[1,2]], not [[3],[4]] or [[4],[3]].

So I've made this quick'n'dirty fix to the bug and it works quite well for me - at least my A\* works as expected now :) 
